### PR TITLE
Aggiunto il modello {{anno}} nella costante URL_XML_FILE_ANNUALE

### DIFF
--- a/app/config.php
+++ b/app/config.php
@@ -90,10 +90,11 @@ define('LICENZA', 'IODL 2.0');
  * IMPOSTARE L'INDIRIZZO INTERNET COMUNICATO ALL'AVCP PER SCARICARE IL FILE.
  *
  * IMPORTANTE! Il programma è fatto per generare file diversi per ogni anno
- * utilizzando la costante URL_XML_FILE_ANNUALE e aggiungendovi alla fine
- * l'anno di riferimento e l'estensione .xml
+ * utilizzando la costante URL_XML_FILE_ANNUALE. Ogni occorrenza di {{anno}}
+ * viene sostituita con l'anno di riferimento e alla fine viene aggiunta
+ * l'estensione .xml
  *
- * Ad es. impostando URL_XML_FILE_ANNUALE col valore 'http://ente.it/trasp_'
+ * Ad es. impostando URL_XML_FILE_ANNUALE col valore 'http://ente.it/trasp_{{anno}}'
  * per l'anno 2012, si genererà un file con indirizzo: 'http://ente.it/trasp_2012.xml'
  *
  * Nel caso si preferisse fare diversamente, è possibile specificare l'indirizzo
@@ -114,7 +115,7 @@ define('LICENZA', 'IODL 2.0');
  */
 
 // Uso il file xml annuale:
-define('URL_XML_FILE_ANNUALE', 'http://www.sito.ente.it/trasparenza/avcp_dataset_');
+define('URL_XML_FILE_ANNUALE', 'http://www.sito.ente.it/trasparenza/avcp_dataset_{{anno}}');
 // oppure commentare la linea precedente e decommentare le due linee successive:
 // define('URL_XML_FILE_ANNUALE', 'NO');
 // define('URL_XML_FILE', 'http://www.sito.ente.it/trasparenza/avcp_dataset.xml');

--- a/app/xml/testa_xml_avcp_query.php
+++ b/app/xml/testa_xml_avcp_query.php
@@ -56,7 +56,11 @@ $XML_TOT .= '<legge190:pubblicazione xsi:schemaLocation="legge190_1_0 datasetApp
 if (URL_XML_FILE_ANNUALE == 'NO') {
     $XML_TOT .= '<urlFile>' . URL_XML_FILE . '</urlFile>' . "\n";
 } else {
-    $XML_TOT .= '<urlFile>' . URL_XML_FILE_ANNUALE . $anno_rif . '.xml</urlFile>' . "\n";
+    $url = strpos(URL_XML_FILE_ANNUALE, '{{anno}}') === false
+        ? URL_XML_FILE_ANNUALE . $anno_rif // Per la retrocompatibilità.
+        : str_replace('{{anno}}', $anno_rif, URL_XML_FILE_ANNUALE);
+
+    $XML_TOT .= '<urlFile>' . $url . '.xml</urlFile>' . "\n";
 }
 
 $XML_TOT .= '

--- a/crea_xml_avcp_query.php
+++ b/crea_xml_avcp_query.php
@@ -52,7 +52,11 @@ echo '<legge190:pubblicazione xsi:schemaLocation="legge190_1_0 datasetAppaltiL19
 if (URL_XML_FILE_ANNUALE == 'NO') {
     echo '<urlFile>' . URL_XML_FILE . '</urlFile>' . PHP_EOL;
 } else {
-    echo '<urlFile>' . URL_XML_FILE_ANNUALE . $anno_rif . '.xml</urlFile>' . PHP_EOL;
+    $url = strpos(URL_XML_FILE_ANNUALE, '{{anno}}') === false
+        ? URL_XML_FILE_ANNUALE . $anno_rif // Per la retrocompatibilità.
+        : str_replace('{{anno}}', $anno_rif, URL_XML_FILE_ANNUALE);
+
+    echo '<urlFile>' . $url . '.xml</urlFile>' . PHP_EOL;
 }
 
 echo '


### PR DESCRIPTION
Questa patch consente di ripetere e specificare la posizione dell'
anno di riferimento nell'URL di pubblicazione.