### PR TITLE
Corretto errore nella procedura di avanzamento gare

### DIFF
--- a/app/model/annoAvanza.php
+++ b/app/model/annoAvanza.php
@@ -61,7 +61,7 @@ if ($_SESSION['user'] == 'admin' && $bloccati[$annoStart] == 'n') {
                     '${oldLotto['sceltaContraente']}',
                     '${oldLotto['importoAggiudicazione']}',
                     '${oldLotto['dataInizio']}',
-                    '${oldLotto['dataUltimazione']}',
+                    NULLIF('${oldLotto['dataUltimazione']}', ''),
                     '${oldLotto['importoSommeLiquidate']}',
                     '${oldLotto['userins']}',
                     'da${annoStart}'


### PR DESCRIPTION
Questa patch risolve un bug nella procedura di avanzamento che impedisce
alle gare senza una data di fine di essere correttamente riportate
all'anno successivo.

Se la data di fine gara non è specificata il valore della colonna
`dataUltimazione` deve essere `NULL` e non la stringa vuota altrimenti
la query genera un errora.